### PR TITLE
Added cli switches to fuzz command to stop after time or first crash

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -399,6 +399,14 @@ pub struct Fuzz {
     /// Set the timeout (in seconds) of the execution of the VM. [0-9]+(ns|us|ms|s|m|h)
     #[clap(long, value_parser = parse_timeout, default_value = "1s")]
     pub(crate) timeout: Duration,
+   
+    /// Set a maximum duration that each core spends on fuzzing.
+    #[clap(long, value_parser = parse_timeout)]
+    pub(crate) stop_after_time: Option<Duration>,
+   
+    /// Stop after the first crash is found
+    #[clap(long)]
+    pub(crate) stop_after_first_crash: bool,
 
     /// Directory to populate the initial input corpus. Defaults to `<project_dir>/input`
     #[clap(short, long)]


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Added two cli switches `--stop-after-time 10s` to stop the fuzzer after a certain amount of time and also `--stop-after-first-crash`. Useful for testing/profiling etc.

Also did a `s/println/log::info/g` to make output nicer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
