### PR TITLE
Several Fixes

### DIFF
--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -1261,7 +1261,8 @@ fn start_core<FUZZER: Fuzzer>(
         log_fuzzvm_perf_stats!(ApplyResetBreakpoint, apply_reset_breakpoints);
         log_fuzzvm_perf_stats!(ApplyCoverageBreakpoint, apply_coverage_breakpoints);
         log_fuzzvm_perf_stats!(InitVm, init_vm);
-        core_stats.lock().unwrap().dirty_pages += try_u64!(guest_reset_perf.restored_pages);
+        core_stats.lock().unwrap().dirty_pages_kvm += try_u64!(guest_reset_perf.restored_kvm_pages);
+        core_stats.lock().unwrap().dirty_pages_custom += try_u64!(guest_reset_perf.restored_custom_pages);
 
         /*
         if guest_reset_perf.restored_pages > 60000 {

--- a/src/fuzzvm.rs
+++ b/src/fuzzvm.rs
@@ -873,18 +873,18 @@ impl<'a, FUZZER: Fuzzer> FuzzVm<'a, FUZZER> {
             }
         }
 
+        // Add all of the reset/crash breakpoints given by the fuzzer
+        if let Some(ref mut reset_bps) = fuzzvm.reset_breakpoints {
+            reset_bps.append(&mut new_reset_bps);
+        }
+
         // Remove all reset breakpoints from the coverage breakpoints if they exist
         // Reset breakpoints take precedence over the coverage breakpoints since they
         // are used to signal resets or crashes
         if let Some(ref mut cov_bps) = fuzzvm.coverage_breakpoints {
-            for (addr, _cr3) in new_reset_bps.keys() {
+            for (addr, _cr3) in fuzzvm.reset_breakpoints.as_ref().unwrap().keys() {
                 cov_bps.remove(addr);
             }
-        }
-
-        // Add all of the reset/crash breakpoints given by the fuzzer
-        if let Some(ref mut reset_bps) = fuzzvm.reset_breakpoints {
-            reset_bps.append(&mut new_reset_bps);
         }
 
         // Init the VM based on the given fuzzer

--- a/src/fuzzvm.rs
+++ b/src/fuzzvm.rs
@@ -427,8 +427,11 @@ pub struct GuestResetPerf {
     /// Amount of time spent during gathering dirty logs from KVM
     pub get_dirty_logs: u64,
 
-    /// Number of pages restored
-    pub restored_pages: u32,
+    /// Number of pages restored from kvm dirty log
+    pub restored_kvm_pages: u32,
+
+    /// Number of pages restored from custom dirty log
+    pub restored_custom_pages: u32,
 
     /// Amount of time during running `fuzzvm.init_guest`
     pub init_guest: InitGuestPerf,
@@ -3301,10 +3304,10 @@ impl<'a, FUZZER: Fuzzer> FuzzVm<'a, FUZZER> {
         time!(get_dirty_logs, self.get_dirty_logs()?);
 
         // Always just restore the dirty pages
-        perf.restored_pages = time!(reset_guest_memory_restore, self.restore_dirty_pages());
+        perf.restored_kvm_pages = time!(reset_guest_memory_restore, self.restore_dirty_pages());
 
         // Reset the guest memory and get the number of pages restored
-        perf.restored_pages += time!(reset_guest_memory_custom, unsafe {
+        perf.restored_custom_pages = time!(reset_guest_memory_custom, unsafe {
             self.reset_custom_guest_memory()?
         });
 

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -25,6 +25,8 @@ pub(crate) const LINUX_USERLAND_SYMBOLS: &[(&str, ResetBreakpointType)] = &[
     ("__GI_raise", ResetBreakpointType::Crash),
     // Reset when we hit exit
     ("__GI_exit", ResetBreakpointType::Reset),
+    // This one is something we see with musl/static linking
+    ("__libc_exit_fini", ResetBreakpointType::Reset),
 ];
 
 /// List of FULL linux kernel symbols that, if hit, signifies a special case to handle.

--- a/utils/plot_stats_diff.py
+++ b/utils/plot_stats_diff.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+"""
+Plot two runs of snapchange side-by-side for comparison.
+
+e.g.,
+```
+cargo run -r -- fuzz ...
+cp -r snapshot/data first
+cargo run -r -- fuzz ...
+cp -r snapshot/data second
+python /path/to/snapchange/plot_stats_diff.py first second
+```
+"""
+
+import sys
+try:
+    import plotext as plt
+except ImportError as e:
+    print(e)
+    print()
+    print("please do: pip install --user plotext")
+    sys.exit(-1)
+
+if len(sys.argv) != 3:
+    print("usage:", sys.argv[0], "./path/to/first/data", "./path/to/second/data")
+    sys.exit(1)
+
+
+def read_data(dir):
+    with open(f"./{dir}/exec_per_sec.plot") as f:
+        execs = [int(x.strip(), 0) for x in f.read().splitlines() if x.strip()]
+    with open(f"./{dir}/dirty_page_per_sec.plot") as f:
+        dirty_pages = [[int(y.strip(), 0) for y in x.strip().split(",") if y.strip()] for x in f.read().splitlines() if x.strip()]
+
+    assert execs
+    assert dirty_pages
+
+    execs_describe = " ".join(map(str, 
+                                  ["execs/sec", 
+                                   "max:", max(execs), 
+                                   "min (!= 0):", min(d for d in execs if d > 0), 
+                                   "avg:", sum(execs) // len(execs)]))
+
+    split_dirty_pages = [
+        [ x[0] for x in dirty_pages ],  # total
+        [ x[1] for x in dirty_pages ],  # kvm
+        [ x[2] for x in dirty_pages ],  # fuzzer/custom
+    ]
+    min_f = 0
+    min_f_seq = [d for d in split_dirty_pages[2] if d > 0]
+    if min_f_seq:
+        min_f = min(min_f_seq)
+    dirty_pages_describe = "".join(map(str, 
+                                  ["dirty_pages/sec (T/K/F) ", 
+                                   "max: ", max(split_dirty_pages[0]), 
+                                   "/", max(split_dirty_pages[1]), 
+                                   "/", max(split_dirty_pages[2]), 
+                                   " min: ", min(d for d in split_dirty_pages[0] if d > 0), 
+                                   "/", min(d for d in split_dirty_pages[1] if d > 0), 
+                                   "/", min_f, 
+                                   " avg: ", sum(split_dirty_pages[0]) // len(dirty_pages),
+                                   "/", sum(split_dirty_pages[1]) // len(dirty_pages),
+                                   "/", sum(split_dirty_pages[2]) // len(dirty_pages),
+                                   ]))
+    return execs, execs_describe, split_dirty_pages, dirty_pages_describe
+
+
+first = read_data(sys.argv[1])
+second = read_data(sys.argv[2])
+
+plt.subplots(2, 2)
+
+# plot execs
+plt.subplot(1, 1)
+plt.plot(first[0])
+plt.title(first[1])
+
+plt.subplot(1, 2)
+plt.plot(second[0])
+plt.title(second[1])
+
+# plot dirty pages
+plt.subplot(2, 1)
+plt.plot(first[2][0], label = "total")
+plt.plot(first[2][1], label = "kvm")
+plt.plot(first[2][2], label = "custom")
+plt.title(first[3])
+
+plt.subplot(2, 2)
+plt.plot(second[2][0], label = "total")
+plt.plot(second[2][1], label = "kvm")
+plt.plot(second[2][2], label = "custom")
+plt.title(second[3])
+
+
+plt.show()


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

four independent smaller contributions in 4 commits:

* Added a default reset breakpoint on `__libc_exit_fini` - for musl statically linked binaries
* With `--ascii-stats` one sees how many dirty pages are reset due to kvm's dirty logs and custom dirty logs (i.e., the user)
* Use the avx page-wise copying code for both custom and kvm page resets.
* A fix for reset breakpoints not taking precedence over coverage breakpoints.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
