### PR TITLE
Extended the `FuzzInput` trait to show some progress during minimize

### DIFF
--- a/src/commands/minimize.rs
+++ b/src/commands/minimize.rs
@@ -151,6 +151,9 @@ fn start_core<FUZZER: Fuzzer>(
     let starting_input: InputWithMetadata<FUZZER::Input> =
         InputWithMetadata::from_path(input_case, project_dir)?;
     let mut input = starting_input.fork();
+    
+    let start_length = input.len();
+    let start_entropy = input.entropy_metric();
 
     // Initialize the performance counters for executing a VM
     let (orig_execution, mut orig_feedback) = fuzzvm.gather_feedback(
@@ -237,6 +240,20 @@ fn start_core<FUZZER: Fuzzer>(
                 "Iters {iters:6}/{max_iterations} | Exec/sec {:6.2}",
                 f64::from(iters) / start.elapsed().as_secs_f64()
             );
+            if let Some(length) = input.len() {
+                log::info!(
+                    "Minimized from {} -> {} bytes",
+                    start_length.unwrap(),
+                    length
+                );
+            }
+            if let Some(entropy) = input.entropy_metric() {
+                log::info!(
+                    "Minimized from {} -> {} entropy metric",
+                    start_entropy.unwrap(),
+                    entropy
+                );
+            }
 
             let curr_time = rdtsc() - timers_start;
 

--- a/src/fuzz_input.rs
+++ b/src/fuzz_input.rs
@@ -146,6 +146,16 @@ pub trait FuzzInput:
             "Redqueen not implemented for this type. Please impl `has_redqueen_rule_candidates`"
         );
     }
+    
+    /// return some kind of entropy metric (e.g., byte entropy), if applicable.
+    fn entropy_metric(&self) -> Option<f64> {
+        None
+    }
+    
+    /// return length of the input, if applicable.
+    fn len(&self) -> Option<usize> {
+        None
+    }
 }
 
 impl FuzzInput for Vec<u8> {
@@ -461,6 +471,16 @@ impl FuzzInput for Vec<u8> {
                 }
             }
         }
+    }
+
+    /// return shannon byte entropy for the bytes slice
+    fn entropy_metric(&self) -> Option<f64> {
+        Some(crate::utils::byte_entropy(self))
+    }
+
+    /// just return the length of the current byte buffer
+    fn len(&self) -> Option<usize> {
+        Some(self.len())
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -95,6 +95,30 @@ pub fn rdtsc() -> u64 {
     unsafe { core::arch::x86_64::_rdtsc() }
 }
 
+
+/// calculate shannon entropy over a byte array
+pub fn byte_entropy<T: AsRef<[u8]>>(buf: T) -> f64 {
+    let buf = buf.as_ref();
+    let mut entropy = 0f64;
+    let mut bytecounts = [0u16; 256];
+    for b in buf.iter().copied() {
+        let b_idx = b as usize;
+        bytecounts[b_idx] = bytecounts[b_idx].saturating_add(1);
+    }
+    let buf_len: f64 = (buf.len() as u32).into();
+    for c in bytecounts.into_iter() {
+        if c == 0 {
+            continue;
+        }
+        let c: f64 = c.into();
+        let p = c / buf_len;
+        entropy -= p * p.log2();
+    }
+
+    entropy
+}
+
+
 /// Returns the hash of the given input using [`DefaultHasher`]
 pub fn calculate_hash<T: Hash>(t: &T) -> u64 {
     let mut s = DefaultHasher::new();


### PR DESCRIPTION
Pretty much the title. I wanted to see whether minimize makes progress so I added two optional methods to the `FuzzInput` trait: `len` and `entropy_metric`.

We could use those also to stop minimization after reaching some kind of fixed point, instead of just following the minimize iteration counts.