### PR TITLE
support for rough (function-level) traces using coverage + symbol breakpoints

### DIFF
--- a/src/addrs.rs
+++ b/src/addrs.rs
@@ -71,7 +71,9 @@ impl VirtAddr {
     #[allow(dead_code)]
     #[must_use]
     pub const fn offset(self, offset: u64) -> VirtAddr {
-        VirtAddr(self.0 + offset)
+        // encountered overflow panics here in debug builds. should be fine letting it overflow, no?
+        // VirtAddr(self.0 + offset)
+        VirtAddr(self.0.overflowing_add(offset).0)
     }
 
     /// Get the 4 page table indexes that this [`VirtAddr`] corresponds maps with when

--- a/src/commands/corpus_min.rs
+++ b/src/commands/corpus_min.rs
@@ -3,7 +3,7 @@
 use anyhow::{ensure, Context, Result};
 
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use std::mem::size_of;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -20,7 +20,7 @@ use crate::fuzz_input::InputWithMetadata;
 use crate::fuzzer::Fuzzer;
 use crate::fuzzvm::{FuzzVm, FuzzVmExit};
 use crate::memory::Memory;
-use crate::{cmdline, fuzzvm, unblock_sigalrm, THREAD_IDS};
+use crate::{cmdline, fuzzvm, unblock_sigalrm, THREAD_IDS, SymbolList};
 use crate::{handle_vmexit, init_environment, KvmEnvironment, ProjectState};
 use crate::{Cr3, Execution, ResetBreakpointType, Symbol, VbCpu, VirtAddr};
 
@@ -279,7 +279,7 @@ pub(crate) fn start_core<FUZZER: Fuzzer>(
     cpuid: &CpuId,
     snapshot_fd: i32,
     clean_snapshot: Arc<RwLock<Memory>>,
-    symbols: &Option<VecDeque<Symbol>>,
+    symbols: &Option<SymbolList>,
     symbol_breakpoints: Option<BTreeMap<(VirtAddr, Cr3), ResetBreakpointType>>,
     coverage_breakpoints: BTreeMap<VirtAddr, u8>,
     vm_timeout: Duration,

--- a/src/commands/coverage.rs
+++ b/src/commands/coverage.rs
@@ -17,7 +17,7 @@ use crate::fuzz_input::InputWithMetadata;
 use crate::fuzzer::Fuzzer;
 use crate::fuzzvm::{FuzzVm, FuzzVmExit};
 use crate::memory::Memory;
-use crate::{cmdline, fuzzvm, unblock_sigalrm, THREAD_IDS};
+use crate::{cmdline, fuzzvm, unblock_sigalrm, THREAD_IDS, SymbolList};
 use crate::{handle_vmexit, init_environment, KvmEnvironment, ProjectState};
 use crate::{Cr3, Execution, ResetBreakpointType, Symbol, VirtAddr};
 
@@ -99,7 +99,7 @@ pub(crate) fn start_core<FUZZER: Fuzzer>(
     cpuid: &CpuId,
     snapshot_fd: i32,
     clean_snapshot: Arc<RwLock<Memory>>,
-    symbols: &Option<VecDeque<Symbol>>,
+    symbols: &Option<SymbolList>,
     symbol_breakpoints: Option<BTreeMap<(VirtAddr, Cr3), ResetBreakpointType>>,
     coverage_breakpoints: BTreeMap<VirtAddr, u8>,
     input_case: &PathBuf,

--- a/src/commands/find_input.rs
+++ b/src/commands/find_input.rs
@@ -19,7 +19,7 @@ use crate::fuzzer::Fuzzer;
 use crate::fuzzvm::{FuzzVm, FuzzVmExit};
 use crate::memory::Memory;
 use crate::stack_unwinder::StackUnwinders;
-use crate::{cmdline, fuzzvm, unblock_sigalrm, THREAD_IDS};
+use crate::{cmdline, fuzzvm, unblock_sigalrm, THREAD_IDS, SymbolList};
 use crate::{handle_vmexit, init_environment, KvmEnvironment, ProjectState};
 use crate::{Cr3, Execution, ResetBreakpointType, Symbol, VbCpu, VirtAddr};
 
@@ -33,7 +33,7 @@ fn start_core<FUZZER: Fuzzer>(
     cpuid: &CpuId,
     snapshot_fd: i32,
     clean_snapshot: Arc<RwLock<Memory>>,
-    symbols: &Option<VecDeque<Symbol>>,
+    symbols: &Option<SymbolList>,
     symbol_breakpoints: Option<BTreeMap<(VirtAddr, Cr3), ResetBreakpointType>>,
     vm_timeout: Duration,
     config: Config,

--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -15,7 +15,7 @@ use core_affinity::CoreId;
 use kvm_bindings::CpuId;
 use kvm_ioctls::VmFd;
 
-use crate::cmdline;
+use crate::{cmdline, SymbolList};
 use crate::cmdline::ProjectCoverage;
 
 use crate::config::Config;
@@ -640,7 +640,7 @@ fn start_core<FUZZER: Fuzzer>(
     cpuid: &CpuId,
     snapshot_fd: i32,
     clean_snapshot: Arc<RwLock<Memory>>,
-    symbols: &Option<VecDeque<Symbol>>,
+    symbols: &Option<SymbolList>,
     symbol_breakpoints: Option<BTreeMap<(VirtAddr, Cr3), ResetBreakpointType>>,
     coverage_breakpoints: Option<BTreeMap<VirtAddr, u8>>,
     core_stats: &Arc<Mutex<Stats<FUZZER>>>,

--- a/src/commands/minimize.rs
+++ b/src/commands/minimize.rs
@@ -19,7 +19,7 @@ use crate::fuzzer::{BreakpointType, Fuzzer};
 use crate::fuzzvm::FuzzVm;
 use crate::memory::Memory;
 use crate::stack_unwinder::StackUnwinders;
-use crate::{fuzzvm, unblock_sigalrm, THREAD_IDS};
+use crate::{fuzzvm, unblock_sigalrm, THREAD_IDS, SymbolList};
 use crate::{init_environment, KvmEnvironment, ProjectState};
 use crate::{Cr3, Execution, ResetBreakpointType, Symbol, VbCpu, VirtAddr};
 
@@ -51,7 +51,7 @@ fn start_core<FUZZER: Fuzzer>(
     cpuid: &CpuId,
     snapshot_fd: i32,
     clean_snapshot: Arc<RwLock<Memory>>,
-    symbols: &Option<VecDeque<Symbol>>,
+    symbols: &Option<SymbolList>,
     symbol_reset_breakpoints: Option<BTreeMap<(VirtAddr, Cr3), ResetBreakpointType>>,
     coverage_breakpoints: Option<FxHashSet<VirtAddr>>,
     input_case: &PathBuf,

--- a/src/commands/redqueen.rs
+++ b/src/commands/redqueen.rs
@@ -24,6 +24,7 @@ use std::{
 
 #[cfg(feature = "redqueen")]
 use crate::{
+    SymbolList,
     cmdline,
     cmp_analysis::RedqueenCoverage,
     feedback::FeedbackLog,
@@ -98,13 +99,15 @@ pub(crate) fn start_core<FUZZER: Fuzzer>(
     cpuid: &CpuId,
     snapshot_fd: i32,
     clean_snapshot: Arc<RwLock<Memory>>,
-    symbols: &Option<VecDeque<Symbol>>,
+    symbols: &Option<SymbolList>,
     symbol_breakpoints: Option<BTreeMap<(VirtAddr, Cr3), ResetBreakpointType>>,
     coverage_breakpoints: BTreeMap<VirtAddr, u8>,
     input_case: &PathBuf,
     project_state: &ProjectState,
 ) -> Result<()> {
     // Store the thread ID of this thread used for passing the SIGALRM to this thread
+
+    use crate::SymbolList;
     let thread_id = unsafe { libc::pthread_self() };
     *THREAD_IDS[core_id.id].lock().unwrap() = Some(thread_id);
 

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -445,13 +445,14 @@ fn start_core<FUZZER: Fuzzer>(
                 || (ret_addrs.contains(&rip) && !matches!(vmret, FuzzVmExit::DebugException))
             {
                 log::trace!("returned from call @ {rip:#x}");
-                indent -= 1;
 
-                let ret = fuzzvm.rax();
                 if let Some(curr_index) = func_indexes.pop() {
                     if let Some(item) = funcs.get_mut(curr_index) {
+                        let ret = fuzzvm.rax();
                         item.1 = Some(ret);
                     }
+
+                    indent = indent.saturating_sub(1);
                 } else {
                     log::warn!("encountered function ret @ {rip:#x} without prior call");
                 }

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -18,7 +18,7 @@ use crate::fuzzer::Fuzzer;
 use crate::fuzzvm::{FuzzVm, FuzzVmExit};
 use crate::interrupts::IdtEntry;
 use crate::memory::Memory;
-use crate::{cmdline, fuzzvm, symbols, unblock_sigalrm, THREAD_IDS};
+use crate::{cmdline, fuzzvm, symbols, unblock_sigalrm, SymbolList, THREAD_IDS};
 use crate::{handle_vmexit, init_environment, KvmEnvironment, ProjectState};
 use crate::{Cr3, Execution, ResetBreakpointType, Symbol, VbCpu, VirtAddr};
 
@@ -34,7 +34,7 @@ fn start_core<FUZZER: Fuzzer>(
     cpuid: &CpuId,
     snapshot_fd: i32,
     clean_snapshot: Arc<RwLock<Memory>>,
-    symbols: &Option<VecDeque<Symbol>>,
+    symbols: &Option<SymbolList>,
     symbol_breakpoints: Option<BTreeMap<(VirtAddr, Cr3), ResetBreakpointType>>,
     coverage_breakpoints: Option<BTreeMap<VirtAddr, u8>>,
     input_case: &Option<PathBuf>,

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1,8 +1,10 @@
 //! Executing the `trace` command
 
 use anyhow::{anyhow, ensure, Context, Result};
+use rustc_hash::FxHashSet;
 
-use std::collections::{BTreeMap, VecDeque};
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
@@ -14,8 +16,8 @@ use kvm_bindings::CpuId;
 use kvm_ioctls::VmFd;
 
 use crate::fuzz_input::InputWithMetadata;
-use crate::fuzzer::Fuzzer;
-use crate::fuzzvm::{FuzzVm, FuzzVmExit};
+use crate::fuzzer::{BreakpointType, Fuzzer};
+use crate::fuzzvm::{BreakpointHook, BreakpointMemory, FuzzVm, FuzzVmExit};
 use crate::interrupts::IdtEntry;
 use crate::memory::Memory;
 use crate::{cmdline, fuzzvm, symbols, unblock_sigalrm, SymbolList, THREAD_IDS};
@@ -101,6 +103,52 @@ fn start_core<FUZZER: Fuzzer>(
     } else {
         log::info!("No single step trace");
         fuzzvm.disable_single_step()?;
+
+        let mut count = 0_usize;
+
+        let cr3 = Cr3(project_state.vbcpu.cr3);
+        // this is not a good idea... many symbols are not code symbols
+        if let Some(symbols) = symbols.as_ref() {
+            log::info!("setting breakpoints on all symbols");
+            for sym in symbols.iter() {
+                let res = fuzzvm.set_breakpoint(
+                    sym.address.into(),
+                    cr3,
+                    BreakpointType::Repeated,
+                    BreakpointMemory::NotDirty,
+                    BreakpointHook::Ignore,
+                );
+                match res {
+                    Ok(_) => count += 1,
+                    Err(_e) => {
+                        let name = &sym.symbol;
+                        let address = &sym.address;
+                        log::trace!("invalid symbol breakpoint for symbols {name} @ {address:#x}");
+                    }
+                }
+            }
+        }
+
+        if let Some(covbps) = project_state.coverage_breakpoints.as_ref() {
+            for addr in covbps.iter() {
+                let res = fuzzvm.set_breakpoint(
+                    *addr,
+                    cr3,
+                    BreakpointType::Repeated,
+                    BreakpointMemory::NotDirty,
+                    BreakpointHook::Ignore,
+                );
+                match res {
+                    Ok(_) => count += 1,
+                    Err(e) => {
+                        let addr = addr.0;
+                        log::debug!("invalid coverage breakpoint for @ {addr:#x}: {e:?}");
+                    }
+                }
+            }
+        }
+
+        log::info!("set {count} breakpoints");
     }
 
     // If the trace input name is `testcase`, allow the fuzzer to do something ahead of
@@ -135,6 +183,8 @@ fn start_core<FUZZER: Fuzzer>(
     } else {
         InputWithMetadata::default()
     };
+
+    let mut vmret = FuzzVmExit::Continue;
 
     for iter in 0..NUMBER_OF_ITERATIONS {
         // Init single allocation for symbol creation and the final resulting trace
@@ -171,13 +221,14 @@ fn start_core<FUZZER: Fuzzer>(
         }
 
         let mut at_call = false;
-        let mut indent = 4;
+        let mut indent = 0_usize;
         let mut func_indexes = Vec::new();
+        let mut ret_addrs = FxHashSet::default();
 
         // Top of the run iteration loop for the current fuzz case
-        for index in 0.. {
+        for index in 0_usize.. {
             // Add the current instruction to the trace
-            let rip = fuzzvm.regs().rip;
+            let rip = fuzzvm.rip();
 
             let cr3 = fuzzvm.cr3();
             let instr = fuzzvm
@@ -265,12 +316,54 @@ fn start_core<FUZZER: Fuzzer>(
                 }
             }
 
+            let rip = fuzzvm.rip();
+            let at_symbol_offset_zero = if let Some(symbols) = fuzzvm.symbols.as_ref() {
+                symbols
+                    .binary_search_by_key(&rip, |Symbol { address, .. }| *address)
+                    .is_ok()
+            } else {
+                false
+            };
+
+            if at_symbol_offset_zero && index > 0 {
+                // function called.
+                log::trace!("call targeted {:#x}", rip);
+                // obtain return address
+                if let Ok(retaddr) = fuzzvm.read::<u64>(fuzzvm.rsp().into(), fuzzvm.cr3()) {
+                    if ret_addrs.insert(retaddr) {
+                        log::trace!("discovered new return address {retaddr:#x}");
+                        let retaddr = VirtAddr(retaddr);
+                        if !fuzzvm.has_breakpoint(retaddr, fuzzvm.cr3()) {
+                            log::debug!("setting retaddr breakpoint for newly discovered return address {retaddr:?}");
+                            // set breakpoint at callsite
+                            let res = fuzzvm.set_breakpoint(
+                                retaddr,
+                                fuzzvm.cr3(),
+                                BreakpointType::Repeated,
+                                BreakpointMemory::NotDirty,
+                                BreakpointHook::Ignore,
+                            );
+                            match res {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    log::debug!("invalid retaddr breakpoint @ {retaddr:?} {e:?}");
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    log::warn!("no return address for call to {:#x}", rip);
+                }
+            }
+
             // At a new call site, write the call arguments
             // If the call site was a jmp, go to the next instruction instead of the jmp site
-            if fuzzvm.single_step && at_call && !instr.contains("jmp") {
+            if (fuzzvm.single_step && at_call && !instr.contains("jmp"))
+                || at_symbol_offset_zero && !matches!(vmret, FuzzVmExit::DebugException)
+            {
                 let symbol = symbol
                     .replace("+0x0", "")
-                    .replace("UnknownSym", &format!("{:#x}", fuzzvm.rip()));
+                    .replace("UnknownSym", &format!("{:#x}", rip));
 
                 let arg1 = fuzzvm.rdi();
                 let arg2 = fuzzvm.rsi();
@@ -332,25 +425,28 @@ fn start_core<FUZZER: Fuzzer>(
             }
 
             // Mark that the next instruction is a call site to write to the function trace
-            if fuzzvm.single_step && instr.contains("call") {
+            if fuzzvm.single_step && (instr.contains("call") || interrupt_routines.contains(&rip)) {
                 at_call = true;
+                indent += 1;
+            }
+            if at_symbol_offset_zero && !matches!(vmret, FuzzVmExit::DebugException) && index > 0 {
                 indent += 1;
             }
 
             // Mark that the next instruction is a call site to write to the function trace
-            if fuzzvm.single_step && interrupt_routines.contains(&rip) {
-                at_call = true;
-                indent += 1;
-            }
-
-            // Mark that the next instruction is a call site to write to the function trace
-            if fuzzvm.single_step && instr.contains("ret") {
-                indent = indent.saturating_sub(1);
+            if (fuzzvm.single_step && instr.contains("ret"))
+                || (ret_addrs.contains(&rip) && !matches!(vmret, FuzzVmExit::DebugException))
+            {
+                log::trace!("returned from call @ {rip:#x}");
+                indent -= 1;
 
                 let ret = fuzzvm.rax();
-                let curr_index = func_indexes.pop().unwrap_or(0xdead);
-                if let Some(item) = funcs.get_mut(curr_index) {
-                    item.1 = Some(ret);
+                if let Some(curr_index) = func_indexes.pop() {
+                    if let Some(item) = funcs.get_mut(curr_index) {
+                        item.1 = Some(ret);
+                    }
+                } else {
+                    log::warn!("encountered function ret @ {rip:#x} without prior call");
                 }
             }
 
@@ -433,13 +529,17 @@ fn start_core<FUZZER: Fuzzer>(
 
             // Reset the VM if the vmexit handler says so
             if matches!(execution, Execution::Reset | Execution::CrashReset { .. }) {
+                log::debug!("stopping tracing at @ {rip:#x}");
                 break;
             }
 
             // Execute the VM
-            let ret = fuzzvm.run()?;
+            vmret = fuzzvm.run()?;
 
-            match ret {
+            let rip = fuzzvm.rip();
+            log::trace!("kvm exit @ {rip:#x} - {vmret:?}");
+
+            match vmret {
                 FuzzVmExit::KasanRead { ip, size, addr } => {
                     // Write the current line to the trace
                     result.push_str(&format!(
@@ -456,7 +556,8 @@ fn start_core<FUZZER: Fuzzer>(
             }
 
             // Handle the FuzzVmExit to determine
-            let ret = handle_vmexit(&ret, &mut fuzzvm, &mut fuzzer, None, &input, None);
+            let ret = handle_vmexit(&vmret, &mut fuzzvm, &mut fuzzer, None, &input, None);
+            log::trace!("handle_vmexit: {ret:?}");
 
             execution = match ret {
                 Err(e) => {
@@ -518,7 +619,7 @@ fn start_core<FUZZER: Fuzzer>(
         log::info!("Writing trace file: {:?}", trace_file);
         std::fs::write(&trace_file, result)?;
 
-        if single_step {
+        if !funcs.is_empty() {
             log::info!("Writing func trace file: {:?}", func_trace_file);
             let mut result = String::new();
             for (func, ret) in funcs {
@@ -544,7 +645,19 @@ fn start_core<FUZZER: Fuzzer>(
         }
 
         // Reset the guest state
-        let _guest_reset_perf = fuzzvm.reset_guest_state(&mut fuzzer)?;
+        fuzzvm.reset_guest_state(&mut fuzzer)?;
+
+        // TODO: how to obtain some reset stats now?
+        // log::info!(
+        //     "Restored {} KVM dirty pages in {}",
+        //     guest_reset_perf.restored_kvm_pages,
+        //     guest_reset_perf.reset_guest_memory_restore
+        // );
+        // log::info!(
+        //     "Restored {} custom dirty pages in {}",
+        //     guest_reset_perf.restored_custom_pages,
+        //     guest_reset_perf.reset_guest_memory_custom
+        // );
 
         // Reset the fuzzer state
         fuzzer.reset_fuzzer_state();
@@ -581,22 +694,41 @@ pub(crate) fn run<FUZZER: Fuzzer>(
         .first()
         .ok_or_else(|| anyhow!("No valid cores"))?;
 
-    let covbp_bytes = BTreeMap::new();
+    // let mut covbp_bytes = BTreeMap::new();
 
-    /*
-    // Apply coverage breakpoints or not
-    let mut mem = crate::memory::Memory::from_addr(clean_snapshot_addr);
-    {
-        let curr_clean_snapshot = clean_snapshot.write().unwrap();
-        let cr3 = Cr3(project_state.vbcpu.cr3);
-        for addr in project_state.coverage_breakpoints.as_ref().unwrap() {
-            if let Ok(orig_byte) = curr_clean_snapshot.read::<u8>(*addr, cr3) {
-                covbp_bytes.insert(*addr, orig_byte);
-                curr_clean_snapshot.write::<u8>(*addr, cr3, 0xcc, crate::memory::WriteMem::Dirty);
-            }
-        }
-    }
-    */
+    // if args.no_single_step {
+    //     if let Some(covbps) = project_state.coverage_breakpoints.as_ref() {
+    //         let cr3 = Cr3(project_state.vbcpu.cr3);
+    //
+    //         // Small scope to drop the clean snapshot lock
+    //         let mut curr_clean_snapshot = clean_snapshot.write().unwrap();
+    //         for addr in covbps {
+    //             if let Ok(orig_byte) = curr_clean_snapshot.read::<u8>(*addr, cr3) {
+    //                 curr_clean_snapshot.write_bytes(*addr, cr3, &[0xcc])?;
+    //                 covbp_bytes.insert(*addr, orig_byte);
+    //             }
+    //         }
+    //     }
+    //
+    //     // make sure there is a breakpoint at each symbol.
+    //     if let Some(symbols) = symbols.as_ref() {
+    //         let cr3 = Cr3(project_state.vbcpu.cr3);
+    //
+    //         // Small scope to drop the clean snapshot lock
+    //         let mut curr_clean_snapshot = clean_snapshot.write().unwrap();
+    //         for sym in symbols.iter() {
+    //             let addr = sym.address.into();
+    //             if let Ok(orig_byte) = curr_clean_snapshot.read::<u8>(addr, cr3) {
+    //                 if orig_byte != 0xcc {
+    //                     curr_clean_snapshot.write_bytes(addr, cr3, &[0xcc])?;
+    //                     covbp_bytes.insert(addr, orig_byte);
+    //                 }
+    //             }
+    //         }
+    //     }
+    //
+    //     log::info!("set {} coverage breakpoints", covbp_bytes.len());
+    // }
 
     // Start executing on this core
     start_core::<FUZZER>(
@@ -608,7 +740,8 @@ pub(crate) fn run<FUZZER: Fuzzer>(
         clean_snapshot,
         &symbols,
         symbol_breakpoints,
-        Some(covbp_bytes), // No need to apply coverage breakpoints for tracing
+        // Some(covbp_bytes),
+        None, // No need to apply coverage breakpoints for tracing
         &args.input,
         args.timeout,
         !args.no_single_step,

--- a/src/fuzzvm.rs
+++ b/src/fuzzvm.rs
@@ -101,6 +101,9 @@ pub enum BreakpointHook<FUZZER: Fuzzer> {
     #[cfg(feature = "redqueen")]
     Redqueen(RedqueenArguments),
 
+    /// intentionally ignore this breakpoint for breakpoint hooks.
+    Ignore,
+
     /// No breakpoint hook function set for this breakpoint
     None,
 }
@@ -2634,6 +2637,9 @@ impl<'a, FUZZER: Fuzzer> FuzzVm<'a, FUZZER> {
                 BreakpointHook::Redqueen(args) => {
                     let args = args.clone();
                     execution = crate::cmp_analysis::gather_comparison(self, input, &args)?;
+                }
+                BreakpointHook::Ignore => {
+                    execution = Execution::Continue;
                 }
                 _ => {
                     let sym = self.get_symbol(virt_addr.0);

--- a/src/fuzzvm.rs
+++ b/src/fuzzvm.rs
@@ -43,7 +43,7 @@ use crate::stats::{PerfMark, PerfStatTimer, Stats};
 use crate::symbols::Symbol;
 
 use crate::vbcpu::VbCpu;
-use crate::{handle_vmexit, Execution, DIRTY_BITMAPS};
+use crate::{handle_vmexit, Execution, DIRTY_BITMAPS, SymbolList};
 use crate::{try_u32, try_u64, try_u8, try_usize};
 
 #[cfg(feature = "redqueen")]
@@ -536,7 +536,7 @@ pub struct FuzzVm<'a, FUZZER: Fuzzer> {
     pub reset_breakpoints: Option<BTreeMap<(VirtAddr, Cr3), ResetBreakpointType>>,
 
     /// List of symbols available in this VM
-    pub symbols: &'a Option<VecDeque<Symbol>>,
+    pub symbols: &'a Option<SymbolList>,
 
     /// Start time of the current fuzz case, used to determine if the VM should be timed
     /// out
@@ -653,7 +653,7 @@ impl<'a, FUZZER: Fuzzer> FuzzVm<'a, FUZZER> {
         clean_snapshot: Arc<RwLock<Memory>>,
         coverage_breakpoints: Option<BTreeMap<VirtAddr, u8>>,
         reset_breakpoints: Option<BTreeMap<(VirtAddr, Cr3), ResetBreakpointType>>,
-        symbols: &'a Option<VecDeque<Symbol>>,
+        symbols: &'a Option<SymbolList>,
         config: Config,
         unwinders: StackUnwinders,
         #[cfg(feature = "redqueen")] redqueen_breakpoints: Option<Vec<(u64, RedqueenArguments)>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,9 @@ impl Execution {
     }
 }
 
+/// List of [`Symbol`] sorted in order by address. Always allows to `binary_search_by_key`.
+pub type SymbolList = Vec<Symbol>;
+
 /// Maximum number of cores supported
 pub(crate) const MAX_CORES: usize = 200;
 
@@ -885,7 +888,7 @@ struct KvmEnvironment {
     clean_snapshot: Arc<RwLock<Memory>>,
 
     /// Parsed symbols if the project has symbols available
-    symbols: Option<VecDeque<Symbol>>,
+    symbols: Option<SymbolList>,
 
     /// Parsed symbol breakpoints if any coverage breakpoints are available in the project
     symbol_breakpoints: Option<BTreeMap<(VirtAddr, Cr3), ResetBreakpointType>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1069,6 +1069,7 @@ pub mod prelude {
         rand,
         rng::Rng,
         snapchange_main, Execution, FuzzInput,
+        InputWithMetadata
     };
 
     #[cfg(feature = "custom_feedback")]

--- a/src/page_table.rs
+++ b/src/page_table.rs
@@ -219,22 +219,22 @@ impl IndexMut<usize> for PageTable {
 #[allow(dead_code)]
 pub struct Translation {
     /// The virtual address for this translation
-    virt_addr: VirtAddr,
+    pub(crate) virt_addr: VirtAddr,
 
     /// The physical address of the translation, if found
-    phys_addr: Option<PhysAddr>,
+    pub(crate) phys_addr: Option<PhysAddr>,
 
     /// The size of the translation page
     pub page_size: Option<PageSize>,
 
     /// [`Permissions`] for this entry
-    perms: Permissions,
+    pub(crate) perms: Permissions,
 
     /// Intermediate physical addresses and their entries for the page table walk
     pub entries: [Option<(u64, Entry)>; 4],
 }
 
-impl Translation {
+impl<'a> Translation {
     /// Create a new [`Translation`] for the [`VirtAddr`]
     pub fn new(
         virt_addr: VirtAddr,
@@ -272,6 +272,29 @@ impl Translation {
     pub fn phys_addr(&self) -> Option<PhysAddr> {
         self.phys_addr
     }
+
+    /// get a copy of the permissions
+    pub fn permissions(&self) -> Permissions {
+        self.perms
+    }
+
+    /// check if translation result points to executable memory
+    #[inline]
+    pub fn is_executable(&self) -> bool {
+        self.perms.executable
+    }
+
+    /// check if translation result points to readable memory
+    #[inline]
+    pub fn is_readable(&self) -> bool {
+        self.perms.readable
+    }
+
+    /// check if translation result points to writable memory
+    #[inline]
+    pub fn is_writable(&self) -> bool {
+        self.perms.writable
+    }
 }
 
 /// The size of the memory containing the translated address
@@ -292,13 +315,13 @@ pub enum PageSize {
 #[allow(dead_code)]
 pub struct Permissions {
     /// The page is readable
-    readable: bool,
+    pub readable: bool,
 
     /// The page is writable
-    writable: bool,
+    pub writable: bool,
 
     /// The page is executable
-    executable: bool,
+    pub executable: bool,
 }
 
 impl Permissions {
@@ -314,7 +337,7 @@ impl Permissions {
     /// Get the writable flag
     #[inline]
     #[allow(dead_code)]
-    pub fn writable(&mut self) -> bool {
+    pub fn writable(&self) -> bool {
         self.writable
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -17,7 +17,7 @@ use tui::text::Span;
 use tui::widgets::ListItem;
 use tui_logger::{TuiWidgetEvent, TuiWidgetState};
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::mem::variant_count;
 use std::path::Path;
@@ -28,6 +28,7 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use crate::SymbolList;
 use crate::addrs::VirtAddr;
 use crate::cmdline::Modules;
 use crate::config::Config;
@@ -871,7 +872,7 @@ pub fn worker<FUZZER: Fuzzer>(
     mut total_feedback: FeedbackTracker,
     input_corpus: &Vec<Arc<InputWithMetadata<FUZZER::Input>>>,
     coverage_breakpoints: Option<BTreeSet<VirtAddr>>,
-    symbols: &Option<VecDeque<Symbol>>,
+    symbols: &Option<SymbolList>,
     mut coverage_analysis: Option<CoverageAnalysis>,
     tui: bool,
     config: &Config, // redqueen_rules: BTreeMap<u64, BTreeSet<RedqueenRule>>
@@ -2180,7 +2181,7 @@ pub fn source_from_address(
 /// Get the `str` for the given address using the symbols and modules of this project
 fn get_symbol_str(
     addr: u64,
-    symbols: &Option<VecDeque<Symbol>>,
+    symbols: &Option<SymbolList>,
     modules: &Modules,
     contexts: &Vec<Context<EndianReader<RunTimeEndian, Rc<[u8]>>>>,
 ) -> Result<String> {

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -67,7 +67,7 @@ pub struct Symbol {
 }
 
 /// Get the symbol for the given `addr` using the given `symbols`
-pub fn get_symbol(addr: u64, symbols: &VecDeque<Symbol>) -> Option<String> {
+pub fn get_symbol(addr: u64, symbols: &crate::SymbolList) -> Option<String> {
     // Get the index to where this address can be found
     let index = symbols.binary_search_by_key(&addr, |Symbol { address, .. }| *address);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,6 +10,7 @@ use std::hash::Hasher;
 use std::path::Path;
 use std::str::FromStr;
 
+use crate::SymbolList;
 use crate::fuzz_input::{FuzzInput, InputWithMetadata};
 use crate::{Symbol, VirtAddr};
 
@@ -206,7 +207,7 @@ pub enum Error {
 /// * Requested symbol is not found
 pub fn parse_cli_symbol(
     possible_virt_addr: &str,
-    symbols: &Option<VecDeque<Symbol>>,
+    symbols: &Option<SymbolList>,
 ) -> Result<VirtAddr> {
     // Parse the given translation address or default to the starting RIP of the snapshot
     let parsed = VirtAddr::from_str(possible_virt_addr);


### PR DESCRIPTION
In case single step takes too long, make it possible to at least generate a rough trace with `--no-single-step`. Sets repeated breakpoints on all coverage breakpoints and symbols. Dynamically sets new breakpoints on return addresses to detect function returns.

plus some smaller misc fixes:

* Uses `SymbolList` type alias instead of manually specifying `VecDeque<Symbol>` everywhere. (this one is actually a `Vec` no and is now always sorted at startup)
* add `InputWithMetadata` to `snapchange::prelude`
* explicitly ignore integer overflow in `VirtAddr::offset` (debug builds only)