### PR TITLE
Consolidated functionality to write coverage to disk into stats module.

### DIFF
--- a/src/addrs.rs
+++ b/src/addrs.rs
@@ -52,9 +52,16 @@ impl std::ops::Deref for PhysAddr {
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Hash)]
 pub struct VirtAddr(pub u64);
 
+// From<u64> for VirtAddr implies Into<VirtAddr> for u64
 impl From<u64> for VirtAddr {
     fn from(val: u64) -> VirtAddr {
         VirtAddr(val)
+    }
+}
+
+impl Into<u64> for VirtAddr {
+    fn into(self) -> u64 {
+        self.0
     }
 }
 

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -499,6 +499,10 @@ pub struct Coverage {
     /// The path to the input to gather coverage for
     pub(crate) path: PathBuf,
 
+    /// The path where to store the inputs files
+    #[clap(long)]
+    pub(crate) coverage_path: Option<PathBuf>,
+
     /// Set the timeout (in seconds) of the execution of the VM. [0-9]+(ns|us|ms|s|m|h)
     #[clap(long, value_parser = parse_timeout, default_value = "1s")]
     pub(crate) timeout: Duration,

--- a/src/commands/coverage.rs
+++ b/src/commands/coverage.rs
@@ -3,6 +3,7 @@
 use anyhow::{anyhow, ensure, Context, Result};
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::convert::Into;
 use std::fs::File;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -17,7 +18,7 @@ use crate::fuzz_input::InputWithMetadata;
 use crate::fuzzer::Fuzzer;
 use crate::fuzzvm::{FuzzVm, FuzzVmExit};
 use crate::memory::Memory;
-use crate::{cmdline, fuzzvm, unblock_sigalrm, THREAD_IDS, SymbolList};
+use crate::{cmdline, fuzzvm, unblock_sigalrm, SymbolList, THREAD_IDS};
 use crate::{handle_vmexit, init_environment, KvmEnvironment, ProjectState};
 use crate::{Cr3, Execution, ResetBreakpointType, Symbol, VirtAddr};
 
@@ -49,28 +50,14 @@ pub(crate) fn run<FUZZER: Fuzzer>(
         .first()
         .ok_or_else(|| anyhow!("No valid cores"))?;
 
-    // Init the coverage breakpoints mapping to byte
-    let mut covbp_bytes = BTreeMap::new();
-
-    let cr3 = Cr3(project_state.vbcpu.cr3);
-
     log::info!(
         "Init {} coverage",
-        project_state.coverage_breakpoints.as_ref().unwrap().len()
+        project_state
+            .coverage_breakpoints
+            .as_ref()
+            .context("coverage command requires coverage breakpoints!")?
+            .len()
     );
-
-    // Small scope to drop the clean snapshot lock after populating the
-    // coverage bytes
-    {
-        let curr_clean_snapshot = clean_snapshot.read().unwrap();
-        for addr in project_state.coverage_breakpoints.as_ref().unwrap() {
-            if let Ok(orig_byte) = curr_clean_snapshot.read_byte(*addr, cr3) {
-                covbp_bytes.insert(*addr, orig_byte);
-            }
-        }
-    }
-
-    log::info!("Found {} coverage", covbp_bytes.keys().len());
 
     // Start executing on this core
     start_core::<FUZZER>(
@@ -81,11 +68,11 @@ pub(crate) fn run<FUZZER: Fuzzer>(
         clean_snapshot,
         &symbols,
         symbol_breakpoints,
-        covbp_bytes,
         &args.path,
         args.timeout,
         project_state,
         args.context,
+        args.coverage_path.as_ref(),
     )?;
 
     // Success
@@ -101,11 +88,11 @@ pub(crate) fn start_core<FUZZER: Fuzzer>(
     clean_snapshot: Arc<RwLock<Memory>>,
     symbols: &Option<SymbolList>,
     symbol_breakpoints: Option<BTreeMap<(VirtAddr, Cr3), ResetBreakpointType>>,
-    coverage_breakpoints: BTreeMap<VirtAddr, u8>,
     input_case: &PathBuf,
     vm_timeout: Duration,
     project_state: &ProjectState,
     display_context: bool,
+    out_path: Option<&PathBuf>,
 ) -> Result<()> {
     // Store the thread ID of this thread used for passing the SIGALRM to this thread
     let thread_id = unsafe { libc::pthread_self() };
@@ -119,12 +106,11 @@ pub(crate) fn start_core<FUZZER: Fuzzer>(
 
     let ProjectState {
         vbcpu,
-        modules,
-        binaries,
         config,
         path: project_dir,
         ..
     } = project_state;
+    let contexts = crate::stats::get_binary_contexts(&project_state.path)?;
 
     // Use the current fuzzer
     let mut fuzzer = FUZZER::default();
@@ -134,33 +120,6 @@ pub(crate) fn start_core<FUZZER: Fuzzer>(
         FUZZER::START_ADDRESS == vbcpu.rip,
         fuzzvm::Error::SnapshotMismatch
     );
-
-    log::info!("Collect the binary contexts");
-    let mut contexts = Vec::new();
-    for binary in binaries {
-        let file = File::open(binary)?;
-        let map = unsafe { memmap::Mmap::map(&file)? };
-        let object = addr2line::object::File::parse(&*map)?;
-        let tmp = addr2line::Context::new(&object)?;
-        contexts.push(tmp);
-    }
-
-    // Initialize the lcov list
-    let mut lcov = BTreeMap::new();
-    for addr in coverage_breakpoints.keys() {
-        let addr = *addr;
-
-        for ctx in &contexts {
-            if let Some(loc) = ctx.find_location(*addr)? {
-                // Insert valid file:line into the BTreeMap for producing lcov
-                if let (Some(file), Some(line)) = (loc.file, loc.line) {
-                    lcov.entry(file)
-                        .or_insert_with(BTreeMap::new)
-                        .insert(line, 0);
-                }
-            }
-        }
-    }
 
     #[cfg(feature = "redqueen")]
     let redqueen_breakpoints = None;
@@ -174,7 +133,7 @@ pub(crate) fn start_core<FUZZER: Fuzzer>(
         cpuid,
         snapshot_fd.as_raw_fd(),
         clean_snapshot,
-        Some(coverage_breakpoints),
+        None,
         symbol_breakpoints,
         symbols,
         config.clone(),
@@ -183,170 +142,81 @@ pub(crate) fn start_core<FUZZER: Fuzzer>(
         redqueen_breakpoints,
     )?;
 
-    log::info!("Coverage timeout: {:?}", vm_timeout);
-
-    let mut execution = Execution::Continue;
-
-    // Init timer to mark how long the tracing took
-    let start = std::time::Instant::now();
-
     // Get the input to trace
     let input = InputWithMetadata::from_path(input_case, &project_dir)?;
 
-    // Set the input into the VM as per the fuzzer
-    fuzzer.set_input(&input, &mut fuzzvm)?;
-
-    let mut coverage = BTreeSet::new();
-
-    // Initialize the coverage symbols
-    let mut symbol_data = String::new();
-
-    // Top of the run iteration loop for the current fuzz case
-    loop {
-        // Reset the VM if the vmexit handler says so
-        if matches!(execution, Execution::Reset | Execution::CrashReset { .. }) {
-            break;
-        }
-
-        // Execute the VM
-        let ret = fuzzvm.run()?;
-
-        if let FuzzVmExit::CoverageBreakpoint(rip) = ret {
-            if coverage.insert(rip) {
-                // Get the symbol for RIP if we have a symbols database
-                if let Some(ref sym_data) = symbols {
-                    // Get the symbol itself
-                    if let Some(curr_symbol) = crate::symbols::get_symbol(rip, sym_data) {
-                        symbol_data.push_str(&curr_symbol.to_string());
-                    }
-
-                    // Add the source line information if we have it
-                    for ctx in &contexts {
-                        if let Some(loc) = ctx.find_location(rip)? {
-                            let curr_line = format!(
-                                "{}:{}:{}",
-                                loc.file.unwrap_or("??"),
-                                loc.line.unwrap_or(0),
-                                loc.column.unwrap_or(0)
-                            );
-
-                            symbol_data.push(' ');
-                            symbol_data.push_str(&curr_line);
-
-                            // Insert valid file:line into the BTreeMap for producing lcov
-                            if let (Some(file), Some(line)) = (loc.file, loc.line) {
-                                lcov.entry(file)
-                                    .or_insert_with(BTreeMap::new)
-                                    .insert(line, 1);
-                            }
-                        }
-                    }
-
-                    // Add the new line
-                    symbol_data.push('\n');
-                }
-            }
-        }
-
-        // Handle the FuzzVmExit to determine
-        let ret = handle_vmexit(&ret, &mut fuzzvm, &mut fuzzer, None, &input, None);
-
-        execution = match ret {
-            Err(e) => {
-                log::info!("ERROR: {:x?}", e);
-                break;
-            }
-            Ok(execution) => execution,
-        };
-
-        // During single step, breakpoints aren't triggered. For this reason,
-        // we need to check if the instruction is a breakpoint regardless in order to
-        // apply fuzzer specific breakpoint logic. We can ignore the "unknown breakpoint"
-        // error that is thrown if a breakpoint is not found;
-        if let Ok(new_execution) = fuzzvm.handle_breakpoint(&mut fuzzer, &input, None) {
-            execution = new_execution;
-        } else {
-            // Ignore the unknown breakpoint case since we check every instruction due to
-            // single stepping here.
-        }
-
-        // Check if the VM needs to be timed out
-        if fuzzvm.start_time.elapsed() > vm_timeout {
-            log::warn!("Coverage Timed out.. exiting");
-            execution = Execution::Reset;
-        }
-    }
+    log::info!(
+        "gathering coverage for input {} with timeout: {:?}",
+        input_case.display(),
+        vm_timeout
+    );
+    // Init timer to mark how long the tracing took
+    let start = std::time::Instant::now();
+    let (execution, feedback) = fuzzvm.gather_feedback(
+        &mut fuzzer,
+        &input,
+        vm_timeout,
+        project_state
+            .coverage_breakpoints
+            .as_ref()
+            .unwrap()
+            .iter()
+            .cloned(),
+        crate::fuzzer::BreakpointType::Repeated,
+    )?;
+    log::info!(
+        "Coverage gathering took {:4.2?} - exit reason: {:?}",
+        start.elapsed(),
+        execution
+    );
 
     let orig_file_name = input_case
         .file_name()
         .unwrap_or_else(|| std::ffi::OsStr::new("UNKNOWNFILENAME"))
         .to_string_lossy();
 
-    let coverage_dir = Path::new("./coverages").join(&*orig_file_name);
+    let coverage_dir = if let Some(out) = out_path {
+        out.clone()
+    } else {
+        project_dir.join("./coverage_per_input")
+    };
     if !coverage_dir.exists() {
         std::fs::create_dir_all(&coverage_dir)?;
     }
 
     // Get the coverage file with just addresses
     let coverage_addrs = coverage_dir.join(format!("{orig_file_name}.coverage_addrs"));
+    // Write the coverage raw addresses file (used with addr2line to get source cov)
+    log::info!("Writing addresses hit to {}", coverage_addrs.display());
+    crate::stats::write_text_coverage(&feedback, &coverage_addrs)?;
 
     // Get the coverage lighthouse file
     let lighthouse_file = coverage_dir.join(format!("{orig_file_name}.coverage_lighthouse"));
-
-    // Get the symbol coverage file
-    let symbols_file = coverage_dir.join(format!("{orig_file_name}.coverage_symbols"));
+    // Wrtie the lighthouse coverage data
+    log::info!(
+        "Writing lighthouse coverage to {}",
+        lighthouse_file.display()
+    );
+    crate::stats::write_lighthouse_coverage(&project_state.modules, &feedback, &lighthouse_file)?;
 
     // Get the lcov coverage file
-    let coverage_lcov = coverage_dir.join(format!("{orig_file_name}.lcov"));
+    let coverage_lcov = coverage_dir.join(format!("{orig_file_name}.lcov.info"));
+    log::info!("Writing lcov coverage to {}", coverage_lcov.display());
+    crate::stats::write_lcov_info(project_state, &contexts, &feedback, &coverage_lcov)?;
 
-    // Collect the lighthouse coverage data
-    let mut lighthouse_data = String::new();
-    for addr in &coverage {
-        if let Some((module, offset)) = modules.contains(*addr) {
-            lighthouse_data.push_str(&format!("{module}+{offset:x}\n"));
-        } else {
-            lighthouse_data.push_str(&format!("{addr:x}\n"));
-        }
-    }
-
-    // Write the lighthouse coverage data
-    log::info!("Writing lighthouse coverage to {lighthouse_file:?}");
-    std::fs::write(&lighthouse_file, &lighthouse_data)
-        .expect("Failed to write coverage lighthouse file");
-
-    if !symbol_data.is_empty() {
-        // Write the lighthouse coverage data
-        log::info!("Writing symbol coverage to {symbols_file:?}");
-        std::fs::write(&symbols_file, &symbol_data)
-            .expect("Failed to write coverage lighthouse file");
-    }
-
-    // Write the coverage raw addresses file (used with addr2line to get source cov)
-    log::info!("Writing addresses hit to {coverage_addrs:?}");
-    std::fs::write(
-        &coverage_addrs,
-        coverage
-            .iter()
-            .map(|addr| format!("{addr:#x}"))
-            .collect::<Vec<_>>()
-            .join("\n"),
-    )
-    .expect("Failed to write coverage address file");
-
-    // Write the lcov output format
-    let mut lcov_res = String::new();
-    lcov_res.push_str("TN:\n");
-    for (file, lines) in &lcov {
-        lcov_res.push_str(&format!("SF:{file}\n"));
-        for (line, hit_val) in lines {
-            lcov_res.push_str(&format!("DA:{line},{hit_val}\n"));
-        }
-        lcov_res.push_str("end_of_record\n");
-    }
-    #[allow(clippy::needless_borrow)]
-    std::fs::write(&coverage_lcov, &lcov_res)?;
-
-    log::info!("Coverage gathering took {:4.2?}", start.elapsed());
+    // write nicely formatted text coverage
+    let symbols_file = coverage_dir.join(format!("{orig_file_name}.coverage_symbols"));
+    log::info!(
+        "Writing human readable coverage to file {}",
+        symbols_file.display()
+    );
+    crate::stats::write_human_readable_text_coverage(
+        project_state,
+        &contexts,
+        symbols.as_ref(),
+        &feedback,
+        symbols_file,
+    )?;
 
     if display_context {
         fuzzvm.print_context()?;

--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -548,12 +548,11 @@ pub(crate) fn run<FUZZER: Fuzzer + 'static>(
         // Start the stats worker
         let res = stats::worker(
             curr_stats,
-            &project_state.modules,
+            &project_state,
             &project_dir,
             prev_coverage,
             &input_corpus,
-            project_state.coverage_breakpoints,
-            &symbols,
+            symbols.as_ref(),
             coverage_analysis,
             tui,
             &project_state.config,

--- a/src/commands/minimize.rs
+++ b/src/commands/minimize.rs
@@ -160,7 +160,7 @@ fn start_core<FUZZER: Fuzzer>(
         &mut fuzzer,
         &starting_input,
         vm_timeout,
-        &covbps_addrs,
+        covbps_addrs.iter().cloned(),
         bp_type,
     )?;
     fuzzvm.print_context()?;
@@ -286,7 +286,7 @@ fn start_core<FUZZER: Fuzzer>(
 
         let (execution, mut feedback) = time!(
             RunInput,
-            fuzzvm.gather_feedback(&mut fuzzer, &curr_input, vm_timeout, &covbps_addrs, bp_type)?
+            fuzzvm.gather_feedback(&mut fuzzer, &curr_input, vm_timeout, covbps_addrs.iter().cloned(), bp_type)?
         );
 
         // Check if the VM resulted in the same crashing state. If so, keep the minimized input as the


### PR DESCRIPTION
Instead of re-implementing writing coverage in lcov, lighthouse, raw in every command, create utility functions in `crate::stats` that can be used to do that. Updated the `coverage` command to remove duplicated code:

1. it uses `fuzzvm.gather_feedback` to obtain coverage
2. it uses the `crate::stats` utility functions
