### PR TITLE
More flexibility when creating fuzzers at the cost of Fuzzers requiring `Clone + Send`.

### DIFF
--- a/examples/01_getpid/src/fuzzer.rs
+++ b/examples/01_getpid/src/fuzzer.rs
@@ -16,7 +16,7 @@ use crate::constants;
 
 const CR3: Cr3 = Cr3(constants::CR3);
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Example1Fuzzer {
     // Fuzzer specific data could go in here
 }

--- a/examples/02_libtiff/src/fuzzer.rs
+++ b/examples/02_libtiff/src/fuzzer.rs
@@ -16,7 +16,7 @@ use crate::constants;
 
 const CR3: Cr3 = Cr3(constants::CR3);
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Example02Fuzzer {
     // Fuzzer specific data could go in here
 }

--- a/examples/03_ffmpeg_custom_mutator/src/fuzzer.rs
+++ b/examples/03_ffmpeg_custom_mutator/src/fuzzer.rs
@@ -15,7 +15,7 @@ use snapchange::linux::{read_args, ReadArgs};
 use snapchange::rng::Rng;
 use snapchange::Execution;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Example03Fuzzer {
     file_offset: usize,
 }

--- a/examples/04_syscall_fuzzer/src/fuzzer.rs
+++ b/examples/04_syscall_fuzzer/src/fuzzer.rs
@@ -82,7 +82,7 @@ const SHELLCODE: u64 = constants::SHELLCODE;
 const SCRATCH: u64 = constants::SCRATCH;
 const CR3: Cr3 = Cr3(constants::CR3);
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Example04Fuzzer {
     /// Offset to the next address to write shellcode
     shellcode_offset: u64,

--- a/examples/05_redqueen/src/fuzzer.rs
+++ b/examples/05_redqueen/src/fuzzer.rs
@@ -12,7 +12,7 @@ const CR3: Cr3 = Cr3(constants::CR3);
 
 // src/fuzzer.rs
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Example05Fuzzer;
 
 impl Fuzzer for Example05Fuzzer {

--- a/examples/06_custom_feedback/src/fuzzer.rs
+++ b/examples/06_custom_feedback/src/fuzzer.rs
@@ -80,7 +80,7 @@ impl std::default::Default for WasdArray {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct MazeFuzzer {
     /// this is used for input scheduling - assigning weights to each input. The latest corpus entry
     /// has the biggest weight, while the first one has the smallest. Essentially this one is a

--- a/examples/07_libfuzzer/src/fuzzer.rs
+++ b/examples/07_libfuzzer/src/fuzzer.rs
@@ -12,7 +12,7 @@ use snapchange::fuzzvm::FuzzVm;
 
 use crate::constants;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Example7Fuzzer {}
 
 impl Fuzzer for Example7Fuzzer {

--- a/src/commands/coverage.rs
+++ b/src/commands/coverage.rs
@@ -109,7 +109,7 @@ pub(crate) fn start_core<FUZZER: Fuzzer>(
         ..
     } = project_state;
     // Use the current fuzzer
-    let mut fuzzer = FUZZER::default();
+    let mut fuzzer = FUZZER::new(project_state);
 
     // Sanity check that the given fuzzer matches the snapshot
     ensure!(

--- a/src/commands/fuzz.rs
+++ b/src/commands/fuzz.rs
@@ -107,7 +107,7 @@ pub(crate) fn run<FUZZER: Fuzzer + 'static>(
 
     log::warn!("Starting all {} worker threads", cores);
 
-    let mut fuzzer = FUZZER::new();
+    let mut fuzzer = FUZZER::new(&project_state);
 
     // Read the input corpus from the given input directory
     let mut input_corpus: Vec<Arc<InputWithMetadata<FUZZER::Input>>> = Vec::new();

--- a/src/commands/minimize.rs
+++ b/src/commands/minimize.rs
@@ -59,10 +59,11 @@ fn start_core<FUZZER: Fuzzer>(
     max_iterations: u32,
     config: Config,
     min_params: MinimizerConfig,
-    project_dir: &PathBuf,
+    project_state: &ProjectState,
 ) -> Result<()> {
+    let project_dir = &project_state.path;
     // Use the current fuzzer
-    let mut fuzzer = FUZZER::default();
+    let mut fuzzer = FUZZER::new(project_state);
 
     // Sanity check that the given fuzzer matches the snapshot
     ensure!(
@@ -467,7 +468,7 @@ pub(crate) fn run<FUZZER: Fuzzer>(
         args.iterations_per_stage,
         project_state.config.clone(),
         minparams,
-        &project_state.path,
+        &project_state,
     )?;
 
     // Success

--- a/src/commands/redqueen.rs
+++ b/src/commands/redqueen.rs
@@ -117,7 +117,7 @@ pub(crate) fn start_core<FUZZER: Fuzzer>(
     } = project_state;
 
     // Use the current fuzzer
-    let mut fuzzer = FUZZER::default();
+    let mut fuzzer = FUZZER::new(project_state);
 
     // Sanity check that the given fuzzer matches the snapshot
     ensure!(

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -64,7 +64,7 @@ fn start_core<FUZZER: Fuzzer>(
     core_affinity::set_for_current(core_id);
 
     // Create a default fuzzer for single shot, tracing execution with the given input
-    let mut fuzzer = FUZZER::default();
+    let mut fuzzer = FUZZER::new(project_state);
 
     log::info!("Fuzzer: {:#x} RIP: {:#x}", FUZZER::START_ADDRESS, vbcpu.rip);
 

--- a/src/fuzzer.rs
+++ b/src/fuzzer.rs
@@ -126,7 +126,7 @@ pub struct Breakpoint<FUZZER: Fuzzer> {
 }
 
 /// Generic fuzzer trait
-pub trait Fuzzer: Default + Sized {
+pub trait Fuzzer: Default + Clone + Sized + Send {
     /// The input type used by this fuzzer
     type Input: FuzzInput + std::panic::RefUnwindSafe;
 
@@ -153,6 +153,11 @@ pub trait Fuzzer: Default + Sized {
         input: &InputWithMetadata<Self::Input>,
         fuzzvm: &mut FuzzVm<Self>,
     ) -> Result<()>;
+
+    /// Create a new fuzzer - only called once, while per-core fuzzers are cloned.
+    fn new() -> Self {
+        Self::default()
+    }
 
     /// Reset the state of the current fuzzer
     fn reset_fuzzer_state(&mut self) {
@@ -321,5 +326,12 @@ pub trait Fuzzer: Default + Sized {
     /// * The target specific fuzzer failed to initialize a filesystem
     fn init_files(&self, _fs: &mut FileSystem) -> Result<()> {
         Ok(())
+    }
+
+
+    /// Load a seed input (stored by default in `./snapshot/inputs/`)
+    fn load_seed_input<P: AsRef<Path>>(&mut self, input_path: P, project_dir: &Path) -> Result<InputWithMetadata<Self::Input>> {
+        let input_path = input_path.as_ref();
+        InputWithMetadata::from_path(input_path, project_dir)
     }
 }

--- a/src/fuzzer.rs
+++ b/src/fuzzer.rs
@@ -15,7 +15,6 @@ use std::sync::{Arc, RwLock};
 
 use crate::addrs::{Cr3, VirtAddr};
 use crate::cmp_analysis::RedqueenRule;
-use crate::expensive_mutators;
 use crate::feedback::FeedbackTracker;
 use crate::filesystem::FileSystem;
 use crate::fuzz_input::{FuzzInput, InputMetadata, InputWithMetadata};
@@ -23,6 +22,7 @@ use crate::fuzzvm::{FuzzVm, HookFn};
 use crate::mutators;
 use crate::rng::Rng;
 use crate::Execution;
+use crate::{expensive_mutators, ProjectState};
 
 /// Type of breakpoint being applied
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -155,7 +155,7 @@ pub trait Fuzzer: Default + Clone + Sized + Send {
     ) -> Result<()>;
 
     /// Create a new fuzzer - only called once, while per-core fuzzers are cloned.
-    fn new() -> Self {
+    fn new(project_state: &ProjectState) -> Self {
         Self::default()
     }
 
@@ -328,9 +328,12 @@ pub trait Fuzzer: Default + Clone + Sized + Send {
         Ok(())
     }
 
-
     /// Load a seed input (stored by default in `./snapshot/inputs/`)
-    fn load_seed_input<P: AsRef<Path>>(&mut self, input_path: P, project_dir: &Path) -> Result<InputWithMetadata<Self::Input>> {
+    fn load_seed_input<P: AsRef<Path>>(
+        &mut self,
+        input_path: P,
+        project_dir: &Path,
+    ) -> Result<InputWithMetadata<Self::Input>> {
         let input_path = input_path.as_ref();
         InputWithMetadata::from_path(input_path, project_dir)
     }


### PR DESCRIPTION
* Added `Fuzzer::load_seed_input` to allow additional or different handling of seed inputs, e.g., parsing seed files that are then stored in a different format internally and in the corpus (e.g., parsing source code into an AST and then doing AST mutations).
* A fuzzer is now constructed with `FUZZER::new` once and then cloned for every core. As a consequence fuzzers are now `Clone + Send`. This allows for several patterns: 
    * Custom shared state across all cores, e.g., for custom metadata. 
    * Performing costly initialization only once (e.g., parsing a system call definition file).